### PR TITLE
Install Conan using pip

### DIFF
--- a/macprep.sh
+++ b/macprep.sh
@@ -4,8 +4,8 @@
 # Tested on MacOS Mojave
 #
 
-### Amend the variables below first, then run from an admin cmd.exe: sudo ~/macprep.sh -action [ACTION]
-## To monitor: tail -f ~/macprep.log
+### Amend the variables below first, then run from a terminal: ~/macprep.sh -Action=ACTION
+## WARNING: DO NOT RUN "build_local_install" ACTION AS ROOT OR SUDO.
 ###
 vstsPatToken=""
 vstsPool="MacOS-Clients"
@@ -99,6 +99,18 @@ function BrewInstall {
 	ReturnCodeCheck "brew_update" $?
 }
 
+function PythonInstall {
+    echo "INFO: Install Python 3 using homebrew"
+
+    brew update
+    brew install python
+    ReturnCodeCheck "python_install" $?
+
+    echo "INFO: Checking that Python command works..."
+    python3 --version
+    ReturnCodeCheck "python_check" $?
+}
+
 function BrewAddBashPath {
 	 pkgName="$1"
 	 
@@ -106,13 +118,13 @@ function BrewAddBashPath {
 }
 
 function ConanInstall {
-	 echo "INFO: Install conan"
-	 brew update
-	 brew install conan
-	 ReturnCodeCheck "conan_install" $? 0
-	 
-	 BrewAddBashPath conan
-	 ReturnCodeCheck "conan_path_add" $?
+    echo "INFO: Install conan using pip"
+    pip3 install 'conan==1.21.1'
+    ReturnCodeCheck "conan_install" $?
+    
+    echo "INFO: Checking that Conan command works..."
+    conan --version
+    ReturnCodeCheck "conan_check" $?
 }
 
 function InstallVstsAgent {
@@ -210,8 +222,10 @@ function VstsAgentRemove {
 
 function Usage {
 	 echo "INFO: Amend the variables at the top of the script, then run from a terminal:" 
-	 echo "INFO:	sudo ~/macprep.sh -Action=ACTION"
+	 echo "INFO:	~/macprep.sh -Action=ACTION"
 	 echo "INFO: Where ACTION is one of: build_local_install|vsts_config|vsts_remove|invoke"
+     echo ""
+     echo "INFO: Do NOT run the build_local_install action as root/sudo!"
 }
 
 function LogSet {
@@ -274,6 +288,7 @@ case $action in
 				echo "INFO: Starting prep for local build system..."
 				InstallXcodeCmdTools
 				BrewInstall
+                PythonInstall
 				ConanInstall
 				InstallAppsBuildLocal
 				BashProfileSource

--- a/macprep.sh
+++ b/macprep.sh
@@ -224,8 +224,8 @@ function Usage {
 	 echo "INFO: Amend the variables at the top of the script, then run from a terminal:" 
 	 echo "INFO:	~/macprep.sh -Action=ACTION"
 	 echo "INFO: Where ACTION is one of: build_local_install|vsts_config|vsts_remove|invoke"
-     echo ""
-     echo "INFO: Do NOT run the build_local_install action as root/sudo!"
+	 echo ""
+	 echo "INFO: Do NOT run the build_local_install action as root/sudo!"
 }
 
 function LogSet {
@@ -288,7 +288,7 @@ case $action in
 				echo "INFO: Starting prep for local build system..."
 				InstallXcodeCmdTools
 				BrewInstall
-                PythonInstall
+				PythonInstall
 				ConanInstall
 				InstallAppsBuildLocal
 				BashProfileSource
@@ -298,6 +298,7 @@ case $action in
 	 #		((
 	 #			 echo "INFO: Starting prep for VSTS build host..."
 	 #			 BrewInstall
+	 #			 PythonInstall
 	 #			 ConanInstall
 	 #			 InstallAppsBuildVsts
 	 #			 OsPrepForAzure

--- a/winprep.ps1
+++ b/winprep.ps1
@@ -4,7 +4,7 @@ param (
 	[Parameter(Mandatory=$false)][string]$funcArgs
 )
 
-$scriptVersion = "1.0.3"
+$scriptVersion = "1.1.0"
 #
 # Windows 10 preparation script for Windows VSTS local and self-hosted build environment setup.
 # Tested on Windows 10 Pro N: Version 1803 (OS Build 17134.1) and Windows Server 2016
@@ -29,11 +29,11 @@ $cmakeVersion = "3.14.5"							# https://chocolatey.org/packages/cmake
 $llvmVersion = "7.0.0"								# Not actively used by us. https://chocolatey.org/packages/llvm
 $azurePipelinesAgentVersion = "2.142.1"		# https://chocolatey.org/packages/azure-pipelines-agent
 $win10sdkVersion = "10.1.17763.1"				# https://chocolatey.org/packages/windows-sdk-10.1
+$pythonVersion = "3.7.6"                          # https://chocolatey.org/packages/Python
 
-$conanVersion = "1_20_4"							# https://conan.io/downloads.html
+$conanVersion = "1.21.1"                          # https://pypi.org/project/conan/
 
 # Others:
-$conanInstallUri = "https://dl.bintray.com/conan/installers/conan-win-64_$conanVersion.exe"
 $vsLlvmUrl = "https://llvmextensions.gallerycdn.vsassets.io/extensions/llvmextensions/llvm-toolchain/1.0.340780/1535663999089/llvm.vsix" # We dont currently use LLVM. https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain 
 $vsClangPowerToolsUrl = "https://marketplace.visualstudio.com/_apis/public/gallery/publishers/caphyon/vsextensions/ClangPowerTools/4.10.5/vspackage"
 $azureAgentUri = "https://go.microsoft.com/fwlink/?LinkID=394789" # This always pulls the latest, see: https://docs.microsoft.com/en-us/azure/virtual-machines/extensions/agent-windows
@@ -137,15 +137,8 @@ function DownloadUri {
 }
 
 function ConanInstall {
-	$conanInstaller = "$Env:TEMP\conanInstaller.exe";
-
-	# Fix powershell stupidity: https://stackoverflow.com/a/39736671 i.e problems downloading from certain URIs
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-	DownloadUri "conan_download" "$conanInstallUri" "$conanInstaller"
-
 	echo "INFO: Install conan: $conanInstaller"
-	StartProcess "conan_install" "$conanInstaller" "/SILENT"
+	StartProcess "conan_install" "pip3" "install conan==$conanVersion"
 }
 
 function WindowsLongPathsEnable {
@@ -194,6 +187,7 @@ packageParameters="--add Microsoft.VisualStudio.Workload.NativeDesktop
 <package id="cmake" version="$cmakeVersion" installArguments="ADD_CMAKE_TO_PATH=System" />
 <package id="git.install" />
 <package id="wixtoolset" />
+<package id="python" version="$pythonVersion" />
 
 <package id="azure-pipelines-agent" version="$azurePipelinesAgentVersion" />
 
@@ -247,6 +241,7 @@ packageParameters="--add Microsoft.VisualStudio.Workload.NativeDesktop
 <package id="cmake" version="$cmakeVersion" installArguments="ADD_CMAKE_TO_PATH=System" />
 <package id="git.install" />
 <package id="wixtoolset" />
+<package id="python" version="$pythonVersion" />
 
 <package id="sysinternals" /> <!-- v.useful debug tools -->
 <package id="conemu" /> <!-- Enhanced cmd.exe CLI -->
@@ -583,7 +578,6 @@ switch ($action)
 				VsCheckVersion $vsLocalType
 				
 				ChocoInstall
-				ConanInstall
 				WindowsLongPathsEnable
 				ChocoInstallAppsBuildLocal
 				LlvmVsInstall $vsLocalType
@@ -603,7 +597,6 @@ switch ($action)
 				TimeSync
 				
 				ChocoInstall
-				ConanInstall
 				WindowsLongPathsEnable
 				DotNet35Install
 				ChocoInstallAppsBuildVsts

--- a/winprep.ps1
+++ b/winprep.ps1
@@ -577,8 +577,8 @@ switch ($action)
 				
 				VsCheckVersion $vsLocalType
 				
-                ChocoInstall
-                ConanInstall
+				ChocoInstall
+				ConanInstall
 				WindowsLongPathsEnable
 				ChocoInstallAppsBuildLocal
 				LlvmVsInstall $vsLocalType
@@ -597,8 +597,8 @@ switch ($action)
 				
 				TimeSync
 				
-                ChocoInstall
-                ConanInstall
+				ChocoInstall
+				ConanInstall
 				WindowsLongPathsEnable
 				DotNet35Install
 				ChocoInstallAppsBuildVsts

--- a/winprep.ps1
+++ b/winprep.ps1
@@ -577,7 +577,8 @@ switch ($action)
 				
 				VsCheckVersion $vsLocalType
 				
-				ChocoInstall
+                ChocoInstall
+                ConanInstall
 				WindowsLongPathsEnable
 				ChocoInstallAppsBuildLocal
 				LlvmVsInstall $vsLocalType
@@ -596,7 +597,8 @@ switch ($action)
 				
 				TimeSync
 				
-				ChocoInstall
+                ChocoInstall
+                ConanInstall
 				WindowsLongPathsEnable
 				DotNet35Install
 				ChocoInstallAppsBuildVsts


### PR DESCRIPTION
This pull request modifies the Windows and macOS build setup scripts to install Python 3 via Choco/Homebrew and then Conan 1.21.1 using pip. Previously, Python was not explicitly installed; Conan was installed using a standalone installer on Windows, and Homebrew on macOS.

Part of the reason for the change is that a new version of Conan was needed to support certain standard packages (such as gtest 1.10). Additionally, pip is the recommended method for installing Conan as it enables recipe linting on Windows and it makes upgrades easier. It also automatically adds Conan to the PATH, meaning build pipelines won't need to use the absolute path to the binary.

I've tested both setup scripts in VMs and they seem to work correctly. I've also manually updated the build agents in the same way and have successfully run test builds.